### PR TITLE
Add bitcoin_hashes dependency to bitcoin_support feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "hammersbald"
 path = "src/lib.rs"
 
 [features]
-bitcoin_support=["bitcoin"]
+bitcoin_support=["bitcoin", "bitcoin_hashes"]
 
 [dependencies]
 rand="0.5"


### PR DESCRIPTION
Fixes:
```
cargo build --features "bitcoin_support"
   Compiling hammersbald v1.6.0 (/home/igor/Code/rust-bitcoin/hammersbald)
error[E0463]: can't find crate for `bitcoin_hashes`
  --> src/lib.rs:32:1
   |
32 | extern crate bitcoin_hashes;
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ can't find crate
```

Related to [murmel #24](https://github.com/rust-bitcoin/murmel/issues/24)